### PR TITLE
revert remove postgres-native-tls

### DIFF
--- a/postgres-native-tls/CHANGELOG.md
+++ b/postgres-native-tls/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Change Log
+
+## v0.5.0 - 2020-12-25
+
+### Changed
+
+* Upgraded to `tokio-postgres` 0.7.
+
+## v0.4.0 - 2020-10-17
+
+### Changed
+
+* Upgraded to `tokio-postgres` 0.6.
+
+## v0.3.0 - 2019-12-23
+
+### Changed
+
+* Upgraded to `tokio-postgres` 0.5.
+
+## v0.3.0-alpha.2 - 2019-11-27
+
+### Changed
+
+* Upgraded to `tokio-postgres` v0.5.0-alpha.2.
+
+## v0.3.0-alpha.1 - 2019-10-14
+
+### Changed
+
+* Updated to `tokio-postgres` v0.5.0-alpha.1.
+
+## v0.2.0-rc.1 - 2019-06-29
+
+### Changed
+
+* Updated to `tokio-postgres` v0.4.0-rc.

--- a/postgres-native-tls/Cargo.toml
+++ b/postgres-native-tls/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "postgres-native-tls"
+version = "0.5.0"
+authors = ["Steven Fackler <sfackler@gmail.com>"]
+edition = "2018"
+license = "MIT OR Apache-2.0"
+description = "TLS support for tokio-postgres via native-tls"
+repository = "https://github.com/sfackler/rust-postgres"
+readme = "../README.md"
+
+[badges]
+circle-ci = { repository = "sfackler/rust-postgres" }
+
+[features]
+default = ["runtime"]
+runtime = ["tokio-postgres/runtime"]
+
+[dependencies]
+native-tls = "0.2"
+tokio = "1.0"
+tokio-native-tls = "0.3"
+tokio-postgres = { version = "0.7.11", path = "../tokio-postgres", default-features = false }
+
+[dev-dependencies]
+futures-util = "0.3"
+tokio = { version = "1.0", features = ["macros", "net", "rt"] }
+postgres = { version = "0.19.8", path = "../postgres" }

--- a/postgres-native-tls/LICENSE-APACHE
+++ b/postgres-native-tls/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/postgres-native-tls/LICENSE-MIT
+++ b/postgres-native-tls/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/postgres-native-tls/src/lib.rs
+++ b/postgres-native-tls/src/lib.rs
@@ -1,0 +1,182 @@
+//! TLS support for `tokio-postgres` and `postgres` via `native-tls`.
+//!
+//! # Examples
+//!
+//! ```no_run
+//! use native_tls::{Certificate, TlsConnector};
+//! # #[cfg(feature = "runtime")]
+//! use postgres_native_tls::MakeTlsConnector;
+//! use std::fs;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # #[cfg(feature = "runtime")] {
+//! let cert = fs::read("database_cert.pem")?;
+//! let cert = Certificate::from_pem(&cert)?;
+//! let connector = TlsConnector::builder()
+//!     .add_root_certificate(cert)
+//!     .build()?;
+//! let connector = MakeTlsConnector::new(connector);
+//!
+//! let connect_future = tokio_postgres::connect(
+//!     "host=localhost user=postgres sslmode=require",
+//!     connector,
+//! );
+//! # }
+//!
+//! // ...
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ```no_run
+//! use native_tls::{Certificate, TlsConnector};
+//! # #[cfg(feature = "runtime")]
+//! use postgres_native_tls::MakeTlsConnector;
+//! use std::fs;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # #[cfg(feature = "runtime")] {
+//! let cert = fs::read("database_cert.pem")?;
+//! let cert = Certificate::from_pem(&cert)?;
+//! let connector = TlsConnector::builder()
+//!     .add_root_certificate(cert)
+//!     .build()?;
+//! let connector = MakeTlsConnector::new(connector);
+//!
+//! let client = postgres::Client::connect(
+//!     "host=localhost user=postgres sslmode=require",
+//!     connector,
+//! )?;
+//! # }
+//! # Ok(())
+//! # }
+//! ```
+#![warn(rust_2018_idioms, clippy::all, missing_docs)]
+
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite, BufReader, ReadBuf};
+use tokio_postgres::tls;
+#[cfg(feature = "runtime")]
+use tokio_postgres::tls::MakeTlsConnect;
+use tokio_postgres::tls::{ChannelBinding, TlsConnect};
+
+#[cfg(test)]
+mod test;
+
+/// A `MakeTlsConnect` implementation using the `native-tls` crate.
+///
+/// Requires the `runtime` Cargo feature (enabled by default).
+#[cfg(feature = "runtime")]
+#[derive(Clone)]
+pub struct MakeTlsConnector(native_tls::TlsConnector);
+
+#[cfg(feature = "runtime")]
+impl MakeTlsConnector {
+    /// Creates a new connector.
+    pub fn new(connector: native_tls::TlsConnector) -> MakeTlsConnector {
+        MakeTlsConnector(connector)
+    }
+}
+
+#[cfg(feature = "runtime")]
+impl<S> MakeTlsConnect<S> for MakeTlsConnector
+where
+    S: AsyncRead + AsyncWrite + Unpin + 'static + Send,
+{
+    type Stream = TlsStream<S>;
+    type TlsConnect = TlsConnector;
+    type Error = native_tls::Error;
+
+    fn make_tls_connect(&mut self, domain: &str) -> Result<TlsConnector, native_tls::Error> {
+        Ok(TlsConnector::new(self.0.clone(), domain))
+    }
+}
+
+/// A `TlsConnect` implementation using the `native-tls` crate.
+pub struct TlsConnector {
+    connector: tokio_native_tls::TlsConnector,
+    domain: String,
+}
+
+impl TlsConnector {
+    /// Creates a new connector configured to connect to the specified domain.
+    pub fn new(connector: native_tls::TlsConnector, domain: &str) -> TlsConnector {
+        TlsConnector {
+            connector: tokio_native_tls::TlsConnector::from(connector),
+            domain: domain.to_string(),
+        }
+    }
+}
+
+impl<S> TlsConnect<S> for TlsConnector
+where
+    S: AsyncRead + AsyncWrite + Unpin + 'static + Send,
+{
+    type Stream = TlsStream<S>;
+    type Error = native_tls::Error;
+    #[allow(clippy::type_complexity)]
+    type Future = Pin<Box<dyn Future<Output = Result<TlsStream<S>, native_tls::Error>> + Send>>;
+
+    fn connect(self, stream: S) -> Self::Future {
+        let stream = BufReader::with_capacity(8192, stream);
+        let future = async move {
+            let stream = self.connector.connect(&self.domain, stream).await?;
+
+            Ok(TlsStream(stream))
+        };
+
+        Box::pin(future)
+    }
+}
+
+/// The stream returned by `TlsConnector`.
+pub struct TlsStream<S>(tokio_native_tls::TlsStream<BufReader<S>>);
+
+impl<S> AsyncRead for TlsStream<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.0).poll_read(cx, buf)
+    }
+}
+
+impl<S> AsyncWrite for TlsStream<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.0).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.0).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.0).poll_shutdown(cx)
+    }
+}
+
+impl<S> tls::TlsStream for TlsStream<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    fn channel_binding(&self) -> ChannelBinding {
+        match self.0.get_ref().tls_server_end_point().ok().flatten() {
+            Some(buf) => ChannelBinding::tls_server_end_point(buf),
+            None => ChannelBinding::none(),
+        }
+    }
+}

--- a/postgres-native-tls/src/test.rs
+++ b/postgres-native-tls/src/test.rs
@@ -1,0 +1,100 @@
+use futures_util::FutureExt;
+use native_tls::{self, Certificate};
+use tokio::net::TcpStream;
+use tokio_postgres::tls::TlsConnect;
+
+#[cfg(feature = "runtime")]
+use crate::MakeTlsConnector;
+use crate::TlsConnector;
+
+async fn smoke_test<T>(s: &str, tls: T)
+where
+    T: TlsConnect<TcpStream>,
+    T::Stream: 'static + Send,
+{
+    let stream = TcpStream::connect("127.0.0.1:5433").await.unwrap();
+
+    let builder = s.parse::<tokio_postgres::Config>().unwrap();
+    let (client, connection) = builder.connect_raw(stream, tls).await.unwrap();
+
+    let connection = connection.map(|r| r.unwrap());
+    tokio::spawn(connection);
+
+    let stmt = client.prepare("SELECT $1::INT4").await.unwrap();
+    let rows = client.query(&stmt, &[&1i32]).await.unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get::<_, i32>(0), 1);
+}
+
+#[tokio::test]
+async fn require() {
+    let connector = native_tls::TlsConnector::builder()
+        .add_root_certificate(
+            Certificate::from_pem(include_bytes!("../../test/server.crt")).unwrap(),
+        )
+        .build()
+        .unwrap();
+    smoke_test(
+        "user=ssl_user dbname=postgres sslmode=require",
+        TlsConnector::new(connector, "localhost"),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn prefer() {
+    let connector = native_tls::TlsConnector::builder()
+        .add_root_certificate(
+            Certificate::from_pem(include_bytes!("../../test/server.crt")).unwrap(),
+        )
+        .build()
+        .unwrap();
+    smoke_test(
+        "user=ssl_user dbname=postgres",
+        TlsConnector::new(connector, "localhost"),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn scram_user() {
+    let connector = native_tls::TlsConnector::builder()
+        .add_root_certificate(
+            Certificate::from_pem(include_bytes!("../../test/server.crt")).unwrap(),
+        )
+        .build()
+        .unwrap();
+    smoke_test(
+        "user=scram_user password=password dbname=postgres sslmode=require",
+        TlsConnector::new(connector, "localhost"),
+    )
+    .await;
+}
+
+#[tokio::test]
+#[cfg(feature = "runtime")]
+async fn runtime() {
+    let connector = native_tls::TlsConnector::builder()
+        .add_root_certificate(
+            Certificate::from_pem(include_bytes!("../../test/server.crt")).unwrap(),
+        )
+        .build()
+        .unwrap();
+    let connector = MakeTlsConnector::new(connector);
+
+    let (client, connection) = tokio_postgres::connect(
+        "host=localhost port=5433 user=postgres sslmode=require",
+        connector,
+    )
+    .await
+    .unwrap();
+    let connection = connection.map(|r| r.unwrap());
+    tokio::spawn(connection);
+
+    let stmt = client.prepare("SELECT $1::INT4").await.unwrap();
+    let rows = client.query(&stmt, &[&1i32]).await.unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get::<_, i32>(0), 1);
+}


### PR DESCRIPTION
Needed to bring TLS to moonlink and pg_mooncake. 