### PR TITLE
Zero copy buffers optimization

### DIFF
--- a/postgres-replication/src/protocol.rs
+++ b/postgres-replication/src/protocol.rs
@@ -1037,3 +1037,461 @@ impl Buffer {
 fn get_str(buf: &[u8]) -> io::Result<&str> {
     str::from_utf8(buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+
+    fn be_i16(x: i16) -> [u8; 2] {
+        x.to_be_bytes()
+    }
+    fn be_u32(x: u32) -> [u8; 4] {
+        x.to_be_bytes()
+    }
+    fn be_i32(x: i32) -> [u8; 4] {
+        x.to_be_bytes()
+    }
+    fn be_u64(x: u64) -> [u8; 8] {
+        x.to_be_bytes()
+    }
+    fn be_i64(x: i64) -> [u8; 8] {
+        x.to_be_bytes()
+    }
+
+    fn cstr(s: &str) -> Vec<u8> {
+        let mut v = Vec::with_capacity(s.len() + 1);
+        v.extend_from_slice(s.as_bytes());
+        v.push(0);
+        v
+    }
+
+    #[test]
+    fn buffer_read_cstr_success() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&cstr("hello"));
+        data.extend_from_slice(b"rest");
+        let mut buf = Buffer {
+            bytes: Bytes::from(data),
+            idx: 0,
+        };
+        let s = buf.read_cstr().unwrap();
+        assert_eq!(get_str(&s).unwrap(), "hello");
+        // Next read should see the first byte of "rest"
+        assert_eq!(buf.read_u8().unwrap(), b'r');
+    }
+
+    #[test]
+    fn buffer_read_cstr_eof() {
+        let mut buf = Buffer {
+            bytes: Bytes::from_static(b"no-null"),
+            idx: 0,
+        };
+        let err = buf.read_cstr().unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn buffer_read_len_ok_and_eof() {
+        let mut buf = Buffer {
+            bytes: Bytes::from_static(b"abcdef"),
+            idx: 0,
+        };
+        let part = buf.read_len(3).unwrap();
+        assert_eq!(&part[..], b"abc");
+        let rest = buf.read_all();
+        assert_eq!(&rest[..], b"def");
+        let mut buf = Buffer {
+            bytes: Bytes::from_static(b"xyz"),
+            idx: 0,
+        };
+        let err = buf.read_len(5).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn replication_message_parse_xlogdata() {
+        let mut v = Vec::new();
+        v.push(XLOG_DATA_TAG);
+        v.extend_from_slice(&be_u64(1));
+        v.extend_from_slice(&be_u64(2));
+        v.extend_from_slice(&be_i64(3));
+        v.extend_from_slice(b"payload");
+        let msg = ReplicationMessage::<Bytes>::parse(&Bytes::from(v)).unwrap();
+        match msg {
+            ReplicationMessage::XLogData(body) => {
+                assert_eq!(body.wal_start(), 1);
+                assert_eq!(body.wal_end(), 2);
+                assert_eq!(body.timestamp(), 3);
+                assert_eq!(&body.data()[..], b"payload");
+            }
+            _ => panic!("expected XLogData"),
+        }
+    }
+
+    #[test]
+    fn replication_message_parse_keepalive() {
+        let mut v = Vec::new();
+        v.push(PRIMARY_KEEPALIVE_TAG);
+        v.extend_from_slice(&be_u64(9));
+        v.extend_from_slice(&be_i64(8));
+        v.push(1);
+        let msg = ReplicationMessage::<Bytes>::parse(&Bytes::from(v)).unwrap();
+        match msg {
+            ReplicationMessage::PrimaryKeepAlive(body) => {
+                assert_eq!(body.wal_end(), 9);
+                assert_eq!(body.timestamp(), 8);
+                assert_eq!(body.reply(), 1);
+            }
+            _ => panic!("expected PrimaryKeepAlive"),
+        }
+    }
+
+    #[test]
+    fn replication_message_parse_unknown_tag() {
+        let v = Bytes::from_static(b"z");
+        let err = ReplicationMessage::<Bytes>::parse(&v).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn logical_parse_begin_commit_origin() {
+        let in_stream = Cell::new(false);
+        // Begin
+        let mut v = Vec::new();
+        v.push(BEGIN_TAG);
+        v.extend_from_slice(&be_u64(100));
+        v.extend_from_slice(&be_i64(200));
+        v.extend_from_slice(&be_u32(300));
+        let msg = LogicalReplicationMessage::parse(&Bytes::from(v), 1, &in_stream).unwrap();
+        match msg {
+            LogicalReplicationMessage::Begin(b) => {
+                assert_eq!(b.final_lsn(), 100);
+                assert_eq!(b.timestamp(), 200);
+                assert_eq!(b.xid(), 300);
+            }
+            _ => panic!("expected Begin"),
+        }
+
+        // Commit
+        let mut v = Vec::new();
+        v.push(COMMIT_TAG);
+        v.push(0);
+        v.extend_from_slice(&be_u64(111));
+        v.extend_from_slice(&be_u64(112));
+        v.extend_from_slice(&be_i64(113));
+        let msg = LogicalReplicationMessage::parse(&Bytes::from(v), 1, &in_stream).unwrap();
+        match msg {
+            LogicalReplicationMessage::Commit(c) => {
+                assert_eq!(c.flags(), 0);
+                assert_eq!(c.commit_lsn(), 111);
+                assert_eq!(c.end_lsn(), 112);
+                assert_eq!(c.timestamp(), 113);
+            }
+            _ => panic!("expected Commit"),
+        }
+
+        // Origin
+        let mut v = Vec::new();
+        v.push(ORIGIN_TAG);
+        v.extend_from_slice(&be_u64(999));
+        v.extend_from_slice(&cstr("origin"));
+        let msg = LogicalReplicationMessage::parse(&Bytes::from(v), 1, &in_stream).unwrap();
+        match msg {
+            LogicalReplicationMessage::Origin(o) => {
+                assert_eq!(o.commit_lsn(), 999);
+                assert_eq!(o.name().unwrap(), "origin");
+            }
+            _ => panic!("expected Origin"),
+        }
+    }
+
+    #[test]
+    fn logical_parse_relation_and_type_with_and_without_xid() {
+        // Relation without xid
+        let in_stream = Cell::new(false);
+        let mut v = Vec::new();
+        v.push(RELATION_TAG);
+        v.extend_from_slice(&be_u32(42)); // rel_id
+        v.extend_from_slice(&cstr("public"));
+        v.extend_from_slice(&cstr("t"));
+        v.push(REPLICA_IDENTITY_DEFAULT_TAG);
+        v.extend_from_slice(&be_i16(1)); // 1 column
+                                         // column
+        v.push(0); // flags
+        v.extend_from_slice(&cstr("id"));
+        v.extend_from_slice(&be_i32(23)); // type_id
+        v.extend_from_slice(&be_i32(-1)); // typmod
+        let msg = LogicalReplicationMessage::parse(&Bytes::from(v), 1, &in_stream).unwrap();
+        match msg {
+            LogicalReplicationMessage::Relation(r) => {
+                assert_eq!(r.xid(), None);
+                assert_eq!(r.rel_id(), 42);
+                assert_eq!(r.namespace().unwrap(), "public");
+                assert_eq!(r.name().unwrap(), "t");
+                assert!(matches!(r.replica_identity(), ReplicaIdentity::Default));
+                assert_eq!(r.columns().len(), 1);
+                assert_eq!(r.columns()[0].flags(), 0);
+                assert_eq!(r.columns()[0].name().unwrap(), "id");
+                assert_eq!(r.columns()[0].type_id(), 23);
+                assert_eq!(r.columns()[0].type_modifier(), -1);
+            }
+            _ => panic!("expected Relation"),
+        }
+
+        // Type with xid
+        let in_stream = Cell::new(true);
+        let mut v = Vec::new();
+        v.push(TYPE_TAG);
+        v.extend_from_slice(&be_u32(7)); // xid present
+        v.extend_from_slice(&be_u32(9999)); // id
+        v.extend_from_slice(&cstr("pg_catalog"));
+        v.extend_from_slice(&cstr("int4"));
+        let msg = LogicalReplicationMessage::parse(&Bytes::from(v), 1, &in_stream).unwrap();
+        match msg {
+            LogicalReplicationMessage::Type(t) => {
+                assert_eq!(t.xid(), Some(7));
+                assert_eq!(t.id(), 9999);
+                assert_eq!(t.namespace().unwrap(), "pg_catalog");
+                assert_eq!(t.name().unwrap(), "int4");
+            }
+            _ => panic!("expected Type"),
+        }
+    }
+
+    fn tuple_bytes(elems: &[TupleData]) -> Vec<u8> {
+        let mut v = Vec::new();
+        v.extend_from_slice(&be_i16(elems.len() as i16));
+        for e in elems {
+            match e {
+                TupleData::Null => v.push(TUPLE_DATA_NULL_TAG),
+                TupleData::UnchangedToast => v.push(TUPLE_DATA_TOAST_TAG),
+                TupleData::Text(b) => {
+                    v.push(TUPLE_DATA_TEXT_TAG);
+                    v.extend_from_slice(&be_i32(b.len() as i32));
+                    v.extend_from_slice(&b[..]);
+                }
+            }
+        }
+        v
+    }
+
+    #[test]
+    fn logical_parse_insert_update_delete_truncate() {
+        // Insert with two tuple items
+        let in_stream = Cell::new(false);
+        let mut v = Vec::new();
+        v.push(INSERT_TAG);
+        v.extend_from_slice(&be_u32(10)); // rel_id
+        v.push(TUPLE_NEW_TAG);
+        let tuple = tuple_bytes(&[TupleData::Null, TupleData::Text(Bytes::from_static(b"42"))]);
+        v.extend_from_slice(&tuple);
+        let msg = LogicalReplicationMessage::parse(&Bytes::from(v), 1, &in_stream).unwrap();
+        match msg {
+            LogicalReplicationMessage::Insert(i) => {
+                assert_eq!(i.xid(), None);
+                assert_eq!(i.rel_id(), 10);
+                assert_eq!(i.tuple().tuple_data().len(), 2);
+            }
+            _ => panic!("expected Insert"),
+        }
+
+        // Update with old then new
+        let mut v = Vec::new();
+        v.push(UPDATE_TAG);
+        v.extend_from_slice(&be_u32(11)); // rel_id
+        v.push(TUPLE_OLD_TAG);
+        v.extend_from_slice(&tuple_bytes(&[TupleData::Text(Bytes::from_static(b"old"))]));
+        v.push(TUPLE_NEW_TAG);
+        v.extend_from_slice(&tuple_bytes(&[TupleData::Text(Bytes::from_static(b"new"))]));
+        let msg = LogicalReplicationMessage::parse(&Bytes::from(v), 1, &Cell::new(false)).unwrap();
+        match msg {
+            LogicalReplicationMessage::Update(u) => {
+                assert!(u.old_tuple().is_some());
+                assert!(u.key_tuple().is_none());
+                assert_eq!(u.new_tuple().tuple_data().len(), 1);
+            }
+            _ => panic!("expected Update"),
+        }
+
+        // Update with key then new
+        let mut v = Vec::new();
+        v.push(UPDATE_TAG);
+        v.extend_from_slice(&be_u32(12));
+        v.push(TUPLE_KEY_TAG);
+        v.extend_from_slice(&tuple_bytes(&[TupleData::Text(Bytes::from_static(b"key"))]));
+        v.push(TUPLE_NEW_TAG);
+        v.extend_from_slice(&tuple_bytes(&[TupleData::Text(Bytes::from_static(b"new"))]));
+        let msg = LogicalReplicationMessage::parse(&Bytes::from(v), 1, &Cell::new(false)).unwrap();
+        match msg {
+            LogicalReplicationMessage::Update(u) => {
+                assert!(u.key_tuple().is_some());
+                assert!(u.old_tuple().is_none());
+            }
+            _ => panic!("expected Update"),
+        }
+
+        // Delete with old
+        let mut v = Vec::new();
+        v.push(DELETE_TAG);
+        v.extend_from_slice(&be_u32(13));
+        v.push(TUPLE_OLD_TAG);
+        v.extend_from_slice(&tuple_bytes(&[TupleData::Text(Bytes::from_static(
+            b"gone",
+        ))]));
+        let msg = LogicalReplicationMessage::parse(&Bytes::from(v), 1, &Cell::new(false)).unwrap();
+        match msg {
+            LogicalReplicationMessage::Delete(d) => {
+                assert!(d.old_tuple().is_some());
+                assert!(d.key_tuple().is_none());
+                assert_eq!(d.rel_id(), 13);
+            }
+            _ => panic!("expected Delete"),
+        }
+
+        // Truncate with two rel_ids and both options unset
+        let mut v = Vec::new();
+        v.push(TRUNCATE_TAG);
+        v.extend_from_slice(&be_i32(2));
+        v.push(0);
+        v.extend_from_slice(&be_u32(100));
+        v.extend_from_slice(&be_u32(200));
+        let msg = LogicalReplicationMessage::parse(&Bytes::from(v), 1, &Cell::new(false)).unwrap();
+        match msg {
+            LogicalReplicationMessage::Truncate(t) => {
+                assert_eq!(t.rel_ids(), &[100, 200]);
+                assert_eq!(t.options(), 0);
+            }
+            _ => panic!("expected Truncate"),
+        }
+    }
+
+    #[test]
+    fn logical_parse_v2_stream_messages_and_state() {
+        let in_stream = Cell::new(false);
+        // StreamStart sets in_streamed_transaction = true
+        let mut v = Vec::new();
+        v.push(STREAM_START_TAG);
+        v.extend_from_slice(&be_u32(777));
+        v.push(1);
+        let msg = LogicalReplicationMessage::parse(&Bytes::from(v), 2, &in_stream).unwrap();
+        match msg {
+            LogicalReplicationMessage::StreamStart(s) => {
+                assert_eq!(s.xid(), 777);
+                assert_eq!(s.is_first_segment(), 1);
+                assert!(in_stream.get());
+            }
+            _ => panic!("expected StreamStart"),
+        }
+
+        // StreamStop sets in_streamed_transaction = false
+        let v = Bytes::from_static(&[STREAM_STOP_TAG]);
+        let msg = LogicalReplicationMessage::parse(&v, 2, &in_stream).unwrap();
+        match msg {
+            LogicalReplicationMessage::StreamStop(_) => {
+                assert!(!in_stream.get());
+            }
+            _ => panic!("expected StreamStop"),
+        }
+
+        // StreamCommit clears state
+        let mut v = Vec::new();
+        v.push(STREAM_COMMIT_TAG);
+        v.extend_from_slice(&be_u32(1));
+        v.push(0);
+        v.extend_from_slice(&be_u64(10));
+        v.extend_from_slice(&be_u64(11));
+        v.extend_from_slice(&be_i64(12));
+        let msg = LogicalReplicationMessage::parse(&Bytes::from(v), 2, &in_stream).unwrap();
+        match msg {
+            LogicalReplicationMessage::StreamCommit(c) => {
+                assert_eq!(c.xid(), 1);
+                assert_eq!(c.flags(), 0);
+                assert_eq!(c.commit_lsn(), 10);
+                assert_eq!(c.end_lsn(), 11);
+                assert_eq!(c.timestamp(), 12);
+                assert!(!in_stream.get());
+            }
+            _ => panic!("expected StreamCommit"),
+        }
+
+        // StreamAbort clears state
+        let mut v = Vec::new();
+        v.push(STREAM_ABORT_TAG);
+        v.extend_from_slice(&be_u32(5));
+        v.extend_from_slice(&be_u32(6));
+        let msg = LogicalReplicationMessage::parse(&Bytes::from(v), 2, &in_stream).unwrap();
+        match msg {
+            LogicalReplicationMessage::StreamAbort(a) => {
+                assert_eq!(a.xid(), 5);
+                assert_eq!(a.subxid(), 6);
+                assert!(!in_stream.get());
+            }
+            _ => panic!("expected StreamAbort"),
+        }
+    }
+
+    #[test]
+    fn tuple_and_tupledata_parsing_edge_cases() {
+        // Zero columns
+        let mut v = Vec::new();
+        v.push(INSERT_TAG);
+        v.extend_from_slice(&be_u32(1));
+        v.push(TUPLE_NEW_TAG);
+        v.extend_from_slice(&be_i16(0));
+        let msg = LogicalReplicationMessage::parse(&Bytes::from(v), 1, &Cell::new(false)).unwrap();
+        match msg {
+            LogicalReplicationMessage::Insert(i) => {
+                assert_eq!(i.tuple().tuple_data().len(), 0);
+            }
+            _ => panic!("expected Insert"),
+        }
+
+        // TupleData variants
+        let mut buf = Buffer {
+            bytes: Bytes::from_static(&[TUPLE_DATA_NULL_TAG]),
+            idx: 0,
+        };
+        assert!(matches!(
+            TupleData::parse(&mut buf).unwrap(),
+            TupleData::Null
+        ));
+
+        let mut buf = Buffer {
+            bytes: Bytes::from_static(&[TUPLE_DATA_TOAST_TAG]),
+            idx: 0,
+        };
+        assert!(matches!(
+            TupleData::parse(&mut buf).unwrap(),
+            TupleData::UnchangedToast
+        ));
+
+        let mut data = Vec::new();
+        data.push(TUPLE_DATA_TEXT_TAG);
+        data.extend_from_slice(&be_i32(3));
+        data.extend_from_slice(b"abc");
+        let mut buf = Buffer {
+            bytes: Bytes::from(data),
+            idx: 0,
+        };
+        match TupleData::parse(&mut buf).unwrap() {
+            TupleData::Text(b) => assert_eq!(&b[..], b"abc"),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn get_str_valid_and_invalid_utf8() {
+        assert_eq!(get_str(b"ok").unwrap(), "ok");
+        let err = get_str(&[0xFF, 0xFE]).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn logical_parse_unknown_tag() {
+        let in_stream = Cell::new(false);
+        let v = Bytes::from_static(b"Z");
+        let err = LogicalReplicationMessage::parse(&v, 1, &in_stream).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+}

--- a/postgres-replication/src/protocol.rs
+++ b/postgres-replication/src/protocol.rs
@@ -49,10 +49,7 @@ pub enum ReplicationMessage<D> {
 impl ReplicationMessage<Bytes> {
     #[inline]
     pub fn parse(buf: &Bytes) -> io::Result<Self> {
-        let mut buf = Buffer {
-            bytes: buf.clone(),
-            idx: 0,
-        };
+        let mut buf = Buffer { bytes: buf.clone() };
 
         let tag = buf.read_u8()?;
 
@@ -203,10 +200,7 @@ impl LogicalReplicationMessage {
         protocol_version: u8,
         in_streamed_transaction: &Cell<bool>,
     ) -> io::Result<Self> {
-        let mut buf = Buffer {
-            bytes: buf.clone(),
-            idx: 0,
-        };
+        let mut buf = Buffer { bytes: buf.clone() };
 
         let tag = buf.read_u8()?;
 
@@ -948,15 +942,9 @@ impl StreamAbortBody {
 
 struct Buffer {
     bytes: Bytes,
-    idx: usize,
 }
 
 impl Buffer {
-    #[inline]
-    fn slice(&self) -> &[u8] {
-        &self.bytes[self.idx..]
-    }
-
     #[inline(always)]
     fn read_cstr(&mut self) -> io::Result<Bytes> {
         let chunk = self.bytes.chunk();
@@ -1073,7 +1061,6 @@ mod tests {
         data.extend_from_slice(b"rest");
         let mut buf = Buffer {
             bytes: Bytes::from(data),
-            idx: 0,
         };
         let s = buf.read_cstr().unwrap();
         assert_eq!(get_str(&s).unwrap(), "hello");
@@ -1085,7 +1072,6 @@ mod tests {
     fn buffer_read_cstr_eof() {
         let mut buf = Buffer {
             bytes: Bytes::from_static(b"no-null"),
-            idx: 0,
         };
         let err = buf.read_cstr().unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
@@ -1095,7 +1081,6 @@ mod tests {
     fn buffer_read_len_ok_and_eof() {
         let mut buf = Buffer {
             bytes: Bytes::from_static(b"abcdef"),
-            idx: 0,
         };
         let part = buf.read_len(3).unwrap();
         assert_eq!(&part[..], b"abc");
@@ -1103,7 +1088,6 @@ mod tests {
         assert_eq!(&rest[..], b"def");
         let mut buf = Buffer {
             bytes: Bytes::from_static(b"xyz"),
-            idx: 0,
         };
         let err = buf.read_len(5).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
@@ -1450,7 +1434,6 @@ mod tests {
         // TupleData variants
         let mut buf = Buffer {
             bytes: Bytes::from_static(&[TUPLE_DATA_NULL_TAG]),
-            idx: 0,
         };
         assert!(matches!(
             TupleData::parse(&mut buf).unwrap(),
@@ -1459,7 +1442,6 @@ mod tests {
 
         let mut buf = Buffer {
             bytes: Bytes::from_static(&[TUPLE_DATA_TOAST_TAG]),
-            idx: 0,
         };
         assert!(matches!(
             TupleData::parse(&mut buf).unwrap(),
@@ -1472,7 +1454,6 @@ mod tests {
         data.extend_from_slice(b"abc");
         let mut buf = Buffer {
             bytes: Bytes::from(data),
-            idx: 0,
         };
         match TupleData::parse(&mut buf).unwrap() {
             TupleData::Text(b) => assert_eq!(&b[..], b"abc"),


### PR DESCRIPTION
Buffer implements `Read`, so every `read_*` from `byteorder::ReadBytesExt` copies bytes into a tiny temp buffer. This happens for every tag, length, and field value length. Additionally, in `TupleData::Text`, we allocate a `Vec<u8>` and `read_exact` into it, then wrap as `Bytes`. This duplicates data already in the original Bytes backing buffer.

In this PR, we replace `Read/ReadBytesExt` with `bytes::Buf` reads and zero-copy slicing; tuple text payloads now use `Bytes::split_to` instead of allocating and copying.

Observed improvement in flamegraphs: large reduction in small memcpy/alloc frames and lower `Tuple::parse` overhead. 

CPU usage drops from 18.90% to 8.5% (~total cpu) for `LogicalReplicationMessage::parse`. 

No behavior changes expected; only internal performance improvements.