### PR TITLE
Add batch API to underlying stream

### DIFF
--- a/postgres-replication/src/lib.rs
+++ b/postgres-replication/src/lib.rs
@@ -29,7 +29,6 @@ pin_project! {
         #[pin]
         stream: CopyBothDuplex<Bytes>,
         raw_scratch: Vec<Result<Message, Error>>,
-        frames_scratch: Vec<Result<ReplicationMessage<LogicalReplicationMessage>, Error>>,
     }
 }
 
@@ -39,7 +38,6 @@ impl ReplicationStream {
         Self {
             stream,
             raw_scratch: Vec::new(),
-            frames_scratch: Vec::new(),
         }
     }
 

--- a/postgres-replication/src/lib.rs
+++ b/postgres-replication/src/lib.rs
@@ -85,6 +85,9 @@ impl ReplicationStream {
         this.stream.send(buf.freeze()).await
     }
 
+    /// Batch-receive up to `max` backend messages and parse CopyData into replication messages.
+    ///
+    /// Clears the `out` buffer before writing and returns the number of items written.
     pub async fn next_batch_msgs(
         self: Pin<&mut Self>,
         out: &mut Vec<Result<ReplicationMessage<Bytes>, Error>>,
@@ -204,6 +207,8 @@ impl LogicalReplicationStream {
             .await
     }
     /// Batches parsed replication messages (driven by CopyBothDuplex::recv_many_* below).
+    ///
+    /// Clears the `out` buffer before writing and returns the number of items written.
     pub async fn next_batch_msgs(
         self: Pin<&mut Self>,
         out: &mut Vec<Result<ReplicationMessage<LogicalReplicationMessage>, Error>>,

--- a/postgres-replication/src/lib.rs
+++ b/postgres-replication/src/lib.rs
@@ -86,7 +86,7 @@ impl ReplicationStream {
     }
 
     pub async fn next_batch_msgs(
-        self: core::pin::Pin<&mut Self>,
+        self: Pin<&mut Self>,
         out: &mut Vec<Result<ReplicationMessage<Bytes>, Error>>,
         max: usize,
     ) -> usize {
@@ -205,7 +205,7 @@ impl LogicalReplicationStream {
     }
     /// Batches parsed replication messages (driven by CopyBothDuplex::recv_many_* below).
     pub async fn next_batch_msgs(
-        self: core::pin::Pin<&mut Self>,
+        self: Pin<&mut Self>,
         out: &mut Vec<Result<ReplicationMessage<LogicalReplicationMessage>, Error>>,
         max: usize,
     ) -> usize {

--- a/postgres-replication/tests/batching.rs
+++ b/postgres-replication/tests/batching.rs
@@ -1,0 +1,176 @@
+use std::cell::Cell;
+
+use futures_util::pin_mut;
+use postgres_replication::protocol::LogicalReplicationMessage;
+use postgres_replication::protocol::ReplicationMessage::{PrimaryKeepAlive, XLogData};
+use postgres_replication::{LogicalReplicationStream, ReplicationStream};
+use tokio_postgres::NoTls;
+use tokio_postgres::SimpleQueryMessage::Row;
+
+#[tokio::test]
+async fn replication_stream_next_batch_msgs_raw() {
+    // form SQL connection
+    let conninfo = "host=127.0.0.1 port=5433 user=postgres replication=database";
+    let (client, connection) = tokio_postgres::connect(conninfo, NoTls).await.unwrap();
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+
+    // Prepare schema and publication
+    client
+        .simple_query("DROP TABLE IF EXISTS test_logical_replication_batch_raw")
+        .await
+        .unwrap();
+    client
+        .simple_query("CREATE TABLE test_logical_replication_batch_raw(i int)")
+        .await
+        .unwrap();
+    client
+        .simple_query("DROP PUBLICATION IF EXISTS test_pub_batch_raw")
+        .await
+        .unwrap();
+    client
+        .simple_query("CREATE PUBLICATION test_pub_batch_raw FOR ALL TABLES")
+        .await
+        .unwrap();
+
+    // Create temporary logical replication slot
+    let slot = "test_logical_slot_batch_raw";
+    let query = format!(
+        r#"CREATE_REPLICATION_SLOT {:?} TEMPORARY LOGICAL "pgoutput""#,
+        slot
+    );
+    let slot_query = client.simple_query(&query).await.unwrap();
+    let lsn = if let Row(row) = &slot_query[1] {
+        row.get("consistent_point").unwrap()
+    } else {
+        panic!("unexpected query message");
+    };
+
+    // Generate a transaction that will appear in the slot's stream
+    client
+        .simple_query("INSERT INTO test_logical_replication_batch_raw VALUES (1)")
+        .await
+        .unwrap();
+
+    // Start logical replication
+    let options = r#"("proto_version" '1', "publication_names" 'test_pub_batch_raw')"#;
+    let start_query = format!(
+        r#"START_REPLICATION SLOT {:?} LOGICAL {} {}"#,
+        slot, lsn, options
+    );
+    let copy_stream = client
+        .copy_both_simple::<bytes::Bytes>(&start_query)
+        .await
+        .unwrap();
+
+    // Wrap in ReplicationStream and batch-recv
+    let stream = ReplicationStream::new(copy_stream);
+    pin_mut!(stream);
+
+    let mut out = Vec::new();
+    let _n = stream.as_mut().next_batch_msgs(&mut out, 16).await;
+
+    // Expect at least one XLogData frame; attempt to parse first logical message inside
+    let mut saw_xlog = false;
+    for item in &out {
+        match item {
+            Ok(XLogData(body)) => {
+                saw_xlog = true;
+                // Validate inner logical message parses
+                let buf = body.data();
+                let _ = LogicalReplicationMessage::parse(buf, 1, &Cell::new(false)).unwrap();
+                break;
+            }
+            Ok(PrimaryKeepAlive(_)) => {}
+            Ok(_) => {}
+            Err(_) => {}
+        }
+    }
+    assert!(saw_xlog, "expected at least one XLogData frame in batch");
+}
+
+#[tokio::test]
+async fn logical_replication_stream_next_batch_msgs_logical() {
+    // form SQL connection
+    let conninfo = "host=127.0.0.1 port=5433 user=postgres replication=database";
+    let (client, connection) = tokio_postgres::connect(conninfo, NoTls).await.unwrap();
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+
+    // Prepare schema and publication
+    client
+        .simple_query("DROP TABLE IF EXISTS test_logical_replication_batch_logical")
+        .await
+        .unwrap();
+    client
+        .simple_query("CREATE TABLE test_logical_replication_batch_logical(i int)")
+        .await
+        .unwrap();
+    client
+        .simple_query("DROP PUBLICATION IF EXISTS test_pub_batch_logical")
+        .await
+        .unwrap();
+    client
+        .simple_query("CREATE PUBLICATION test_pub_batch_logical FOR ALL TABLES")
+        .await
+        .unwrap();
+
+    // Create temporary logical replication slot
+    let slot = "test_logical_slot_batch_logical";
+    let query = format!(
+        r#"CREATE_REPLICATION_SLOT {:?} TEMPORARY LOGICAL "pgoutput""#,
+        slot
+    );
+    let slot_query = client.simple_query(&query).await.unwrap();
+    let lsn = if let Row(row) = &slot_query[1] {
+        row.get("consistent_point").unwrap()
+    } else {
+        panic!("unexpected query message");
+    };
+
+    // Generate a transaction that will appear in the slot's stream
+    client
+        .simple_query(
+            "BEGIN; INSERT INTO test_logical_replication_batch_logical VALUES (2); COMMIT;",
+        )
+        .await
+        .unwrap();
+
+    // Start logical replication
+    let options = r#"("proto_version" '1', "publication_names" 'test_pub_batch_logical')"#;
+    let start_query = format!(
+        r#"START_REPLICATION SLOT {:?} LOGICAL {} {}"#,
+        slot, lsn, options
+    );
+    let copy_stream = client
+        .copy_both_simple::<bytes::Bytes>(&start_query)
+        .await
+        .unwrap();
+
+    let stream = LogicalReplicationStream::new(copy_stream, Some(1));
+    tokio::pin!(stream);
+
+    let mut out = Vec::new();
+
+    // Pull a batch and expect at least one logical XLogData message
+    let _n = stream.as_mut().next_batch_msgs(&mut out, 16).await;
+
+    let mut have_any = false;
+    for item in &out {
+        match item {
+            Ok(XLogData(_)) => {
+                have_any = true;
+                break;
+            }
+            Ok(PrimaryKeepAlive(_)) => {}
+            Ok(_) => {}
+            Err(_) => {}
+        }
+    }
+    assert!(
+        have_any,
+        "expected at least one logical XLogData frame in batch"
+    );
+}

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -57,7 +57,7 @@ phf = "0.11"
 postgres-protocol = { version = "0.6.7", path = "../postgres-protocol" }
 postgres-types = { version = "0.2.7", path = "../postgres-types" }
 serde = { version = "1.0", optional = true }
-tokio = { version = "1.27", features = ["io-util"] }
+tokio = { version = "1.32", features = ["io-util", "sync"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 rand = "0.8.5"
 whoami = "1.4.1"

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -125,9 +125,10 @@ impl InnerClient {
     }
 
     pub fn start_copy_both(&self) -> Result<CopyBothHandles, Error> {
-        let (sender, receiver) = mpsc::channel(16);
-        let (stream_sender_raw, stream_receiver) = tmpsc::channel(16);
-        let (sink_sender_raw, sink_receiver) = tmpsc::channel(16);
+        let channel_size = 4_096;
+        let (sender, receiver) = mpsc::channel(channel_size);
+        let (stream_sender_raw, stream_receiver) = tmpsc::channel(channel_size);
+        let (sink_sender_raw, sink_receiver) = tmpsc::channel(channel_size);
         let sink_sender = PollSender::new(sink_sender_raw);
         let stream_sender = PollSender::new(stream_sender_raw);
 

--- a/tokio-postgres/src/copy_both.rs
+++ b/tokio-postgres/src/copy_both.rs
@@ -273,7 +273,7 @@ impl<T> CopyBothDuplex<T> {
     /// Drain up to `max` raw protocol messages from the receiver in **one await**.
     /// Reuses the caller's buffer; returns the number of items written.
     pub async fn recv_many_raw(
-        self: core::pin::Pin<&mut Self>,
+        self: Pin<&mut Self>,
         out: &mut Vec<Result<Message, Error>>,
         max: usize,
     ) -> usize {

--- a/tokio-postgres/src/copy_both.rs
+++ b/tokio-postgres/src/copy_both.rs
@@ -273,13 +273,14 @@ impl<T> CopyBothDuplex<T> {
     /// Drain up to `max` raw protocol messages from the receiver in **one await**.
     /// Reuses the caller's buffer; returns the number of items written.
     pub async fn recv_many_raw(
-        &mut self,
+        self: core::pin::Pin<&mut Self>,
         out: &mut Vec<Result<Message, Error>>,
         max: usize,
     ) -> usize {
+        let mut this = self.project();
         out.clear();
         out.reserve(max);
-        self.stream_receiver.recv_many(out, max).await
+        this.stream_receiver.recv_many(out, max).await
     }
 }
 

--- a/tokio-postgres/tests/test/copy_both.rs
+++ b/tokio-postgres/tests/test/copy_both.rs
@@ -158,3 +158,101 @@ async fn copy_both_future_cancellation() {
         }
     }
 }
+
+// New tests for tokio-based batching and closure semantics
+use bytes::Bytes as RawBytes;
+use postgres_protocol::message::backend::Message;
+
+#[tokio::test]
+async fn copy_both_recv_many_raw_batches() {
+    let client = crate::connect("user=postgres replication=database").await;
+
+    // Prepare data
+    q(&client, "DROP TABLE IF EXISTS replication_b").await;
+    q(&client, "CREATE TABLE replication_b (i text)").await;
+    let slot_query = "CREATE_REPLICATION_SLOT slot_b TEMPORARY LOGICAL \"test_decoding\"";
+    let lsn = q(&client, slot_query).await[0]
+        .get("consistent_point")
+        .unwrap()
+        .to_owned();
+    q(&client, "BEGIN").await;
+    q(&client, "INSERT INTO replication_b VALUES ('a')").await;
+    q(&client, "INSERT INTO replication_b VALUES ('b')").await;
+    q(&client, "COMMIT").await;
+
+    let query = format!("START_REPLICATION SLOT slot_b LOGICAL {}", lsn);
+    let mut duplex = client
+        .copy_both_simple::<RawBytes>(&query)
+        .await
+        .expect("copy_both_simple");
+
+    // Batch fetch with different max sizes
+    let mut out = Vec::<Result<Message, tokio_postgres::Error>>::new();
+
+    let n1 = duplex.recv_many_raw(&mut out, 1).await;
+    assert!(n1 <= 1);
+    assert!(out
+        .iter()
+        .take(n1)
+        .all(|r| matches!(r, Ok(Message::CopyData(_)) | Ok(_))));
+
+    out.clear();
+    let n2 = duplex.recv_many_raw(&mut out, 16).await;
+    assert!(n2 >= 1);
+    // At least one XLogData (starts with 'w') should be present
+    let have_w = out
+        .iter()
+        .take(n2)
+        .any(|r| matches!(r, Ok(Message::CopyData(cd)) if cd.data()[0] == b'w'));
+    assert!(have_w);
+}
+
+#[tokio::test]
+async fn copy_both_recv_many_raw_zero_max() {
+    let client = crate::connect("user=postgres replication=database").await;
+
+    let slot_query = "CREATE_REPLICATION_SLOT slot_zero TEMPORARY LOGICAL \"test_decoding\"";
+    let lsn = q(&client, slot_query).await[0]
+        .get("consistent_point")
+        .unwrap()
+        .to_owned();
+
+    let query = format!("START_REPLICATION SLOT slot_zero LOGICAL {}", lsn);
+    let mut duplex = client
+        .copy_both_simple::<RawBytes>(&query)
+        .await
+        .expect("copy_both_simple");
+
+    let mut out = Vec::<Result<Message, tokio_postgres::Error>>::new();
+    let n = duplex.recv_many_raw(&mut out, 0).await;
+    assert_eq!(n, 0);
+    assert!(out.is_empty());
+}
+
+#[tokio::test]
+async fn copy_both_error_with_recv_many_raw() {
+    let client = crate::connect("user=postgres replication=database").await;
+
+    q(
+        &client,
+        "CREATE_REPLICATION_SLOT err_many TEMPORARY PHYSICAL",
+    )
+    .await;
+
+    // Enter CopyBoth and get an error
+    let mut duplex = client
+        .copy_both_simple::<RawBytes>("START_REPLICATION SLOT err_many PHYSICAL FFFF/FFFF")
+        .await
+        .unwrap();
+
+    let mut out = Vec::<Result<Message, tokio_postgres::Error>>::new();
+    let n = duplex.recv_many_raw(&mut out, 8).await;
+    assert!(n >= 1);
+    assert!(out
+        .iter()
+        .take(n)
+        .any(|r| matches!(r, Err(e) if e.as_db_error().is_some())));
+
+    // Ensure connection remains usable
+    assert_eq!(q(&client, "SELECT 1").await[0].get(0), Some("1"));
+}


### PR DESCRIPTION
The original stream implementation consumed one backend message per await, parsing each frame individually as it arrived. This per-message await and parse path increases scheduling overhead, adds latency under load, and makes it harder to achieve good throughput since each message requires a separate wakeup and parse allocation. The logical conversion also duplicated parsing logic between the stream’s poll path and any higher-level handling.

This change introduces a batching model that keeps the same external `Stream` semantics while reducing per-message overhead. 

`CopyBothDuplex` now exposes `recv_many_raw` by switching to using a `tokio::sync::mpsc` rather than the `futures::mpsc`. This allows us to use the [recv_many](https://docs.rs/tokio/latest/tokio/sync/mpsc/struct.Receiver.html#method.recv_many) API. This drains up to N backend messages into a caller-provided buffer in a single await. 

`ReplicationStream` builds on that with `next_batch_msgs`, which takes a mutable output buffer, clears it, and fills it with parsed `ReplicationMessage<Bytes>` results for each CopyData message.

`LogicalReplicationStream` adds its own `next_batch_msgs` which reuses the underlying batch parsing, then converts each raw replication message into a logical one via a shared `convert_raw_msg` helper. 

Both layers reuse internal scratch buffers to minimize allocations across batches.
 
Overall, this preserves existing behavior while enabling much more efficient consumption patterns by allowing users to parse and process multiple frames per await with fewer allocations and reduced wakeups.

In a follow up PR on the moonlink side we will expose this API, implement it, and then measure the performance impact. 